### PR TITLE
Avoid busy loop

### DIFF
--- a/mrblib/grenadine/container.rb
+++ b/mrblib/grenadine/container.rb
@@ -89,7 +89,7 @@ Options
       end
 
       puts "Containerized process (#{pid}:#{@argv.inspect}) is starting..."
-      ml = FiberedWorker::MainLoop.new
+      ml = FiberedWorker::MainLoop.new(interval: 5)
       ml.pid = pid
       s = ml.run
       puts "exited: #{s.inspect}"

--- a/mrblib/grenadine/restorer.rb
+++ b/mrblib/grenadine/restorer.rb
@@ -103,7 +103,7 @@ Options
 
       def supervise
         @pidfile = Pidfile.create Container::GREN_SV_PIDFILE_PATH
-        ml = FiberedWorker::MainLoop.new
+        ml = FiberedWorker::MainLoop.new(interval: 5)
         ml.pid = @pid
         s = ml.run
         puts "exited: #{s.inspect}"


### PR DESCRIPTION
```
root     11744 99.9  0.3  16516  3736 ?        R    11:44   9:52 /usr/local/bin/grenadine restore                                                                             
vagrant  11749  0.0  1.8 236348 18652 ?        Ssl  11:44   0:00  \_ ruby app.rb
```

Default `FiberedWorker::MainLoop` makes busy loop.